### PR TITLE
Breaking changes in dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "polymer": "~1.1.1",
     "polymer-ts": "~0.1.14",
     "system.js": "~0.18.17",
-    "systemjs-plugin-html": "https://github.com/Hypercubed/systemjs-plugin-html.git#~0.0.6"
+    "systemjs-plugin-html": "https://github.com/Hypercubed/systemjs-plugin-html.git#0.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "express": "^4.13.3",
-    "typescript": "^1.5.3"
+    "typescript": "1.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "express": "^4.13.3",
-    "typescript": "1.5.3"
+    "typescript": "^1.5.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"declaration": false,
-		"module": "CommonJS",
+		"module": "system",
 		"target": "es5",
 		"noImplicitAny": false,
 		"experimentalDecorators": true


### PR DESCRIPTION
The systemjs-plugin-html 0.0.8 no more calls
System.import('webcomponentsjs/webcomponents-lite.min'); which
effectively breaks the demo.

[App is responsible for loading Web Components polyfill](https://github.com/Hypercubed/systemjs-plugin-html/commit/9d2e5e9660c8cf95173c3b1aa7018be809d30f7d)

Also the newer versions of typescript
breaks compilation leading to a situation in which the
elements/app-frontend.ts isn't compiled when issuing `npm run tsc`.

To keep the demo working while a better fix is found, I've set the
aforementioned dependencies to specific versions.
