### PR TITLE
Breaking changes in dependency and tsconfig.json fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "polymer": "~1.1.1",
     "polymer-ts": "~0.1.14",
     "system.js": "~0.18.17",
-    "systemjs-plugin-html": "https://github.com/Hypercubed/systemjs-plugin-html.git#0.0.6"
+    "systemjs-plugin-html": "https://github.com/Hypercubed/systemjs-plugin-html.git#~0.0.8",
+    "webcomponentsjs": "^0.7.22"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "polymer": "~1.1.1",
     "polymer-ts": "~0.1.14",
     "system.js": "~0.18.17",
-    "systemjs-plugin-html": "https://github.com/Hypercubed/systemjs-plugin-html.git#~0.0.6"
+    "systemjs-plugin-html": "https://github.com/Hypercubed/systemjs-plugin-html.git#0.0.6"
   }
 }

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 		href="bower_components/charto-polymer-shim/hide.css" />
 
 	<script src="bower_components/system.js/dist/system.js"></script>
+    <script src="bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 	<script src="bower_components/charto-polymer-shim/loader.js"></script>
 	<script src="config.js"></script>
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "express": "^4.13.3",
-    "typescript": "^1.5.3"
+    "typescript": "1.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "devDependencies": {
     "express": "^4.13.3",
-    "typescript": "1.5.3"
+    "typescript": "^1.5.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"declaration": false,
-		"module": "CommonJS",
+		"module": "system",
 		"target": "es5",
 		"noImplicitAny": false,
 		"experimentalDecorators": true


### PR DESCRIPTION
### Hard coded systemjs-plugin-html -version

The systemjs-plugin-html 0.0.8 no more calls
System.import('webcomponentsjs/webcomponents-lite.min'); which
effectively breaks the demo.

See: [App is responsible for loading Web Components polyfill](https://github.com/Hypercubed/systemjs-plugin-html/commit/9d2e5e9660c8cf95173c3b1aa7018be809d30f7d)

---
### Changed tsconfig.json to state the intent to use system.js

Otherwise imports under elements folder aren't compiled when issuing `npm run tsc`
